### PR TITLE
fix layout

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
           <div className="absolute top-[1542px] left-[-217px] h-[368px] w-[368px] rounded-full bg-[#F05625] opacity-85 blur-[250px]" />
           <div className="absolute top-[2399px] left-[-239px] h-[368px] w-[368px] rounded-full bg-[#F05625] opacity-85 blur-[250px]" />
 
-          <div className="relative top-[30px]">
+          <div className="relative top-[800px]">
             <div className="absolute right-[-52.73px]">
               <Image src={StringOrnament} alt="String Ornament" />
             </div>
@@ -37,13 +37,13 @@ export default function Home() {
             </div>
           </div>
 
-          <div className="absolute top-[200px] right-[0px]">
+          <div className="absolute top-[0px] right-[0px]">
             <Image src={BgDotLowOpacity1} alt="Background Dot Low Opacity 1" />
           </div>
-          <div className="absolute top-[290px] left-[0px]">
+          <div className="absolute top-[0px] left-[0px]">
             <Image src={BgDotLowOpacity1} alt="Background Dot Low Opacity 1" />
           </div>
-          <div className="absolute top-[2000px] right-[0px]">
+          <div className="absolute top-[2200px] right-[0px]">
             <Image
               src={BgDot1}
               alt="Background Dot 1"
@@ -51,13 +51,13 @@ export default function Home() {
               height={159}
             />
           </div>
-          <div className="absolute top-[2200px] left-[-22px]">
+          <div className="absolute top-[2580px] left-[-22px]">
             <Image src={BgDot2} alt="Background Dot 2" />
           </div>
-          <div className="absolute top-[1050px] right-[0] bottom-0 h-[162.54px] w-full min-w-[476.28px]">
+          <div className="absolute top-[1700px] right-[0] bottom-0 h-[162.54px] w-full min-w-[476.28px]">
             <Image src={WaveLine2} alt="Wave Line Ornament" width={500} />
           </div>
-          <div className="absolute top-[1500px] right-[-260px] bottom-0 h-[162.54px] w-full min-w-[476.28px]">
+          <div className="absolute top-[1300px] right-[-260px] bottom-0 h-[162.54px] w-full min-w-[476.28px]">
             <Image
               src={StringOrnament}
               alt="String Ornament"

--- a/src/components/attendance/attendance.tsx
+++ b/src/components/attendance/attendance.tsx
@@ -6,7 +6,7 @@ import WomanDresscode from "/public/assets/images/woman-dresscode.svg";
 
 const Attendance = () => {
   return (
-    <div className="min-h-[842px]">
+    <div className="mt-30 min-h-screen">
       <div className="flex items-center justify-center text-center">
         <div className="m-14 inline-block space-y-4 text-white">
           <AnimatedElement>

--- a/src/components/date-time/date-time.tsx
+++ b/src/components/date-time/date-time.tsx
@@ -5,7 +5,7 @@ import { Button } from "../ui/button";
 
 const DateTime = () => {
   return (
-    <div className="relative mt-56 flex min-h-[844px] w-full items-center justify-center px-12 text-white">
+    <div className="relative mt-56 flex min-h-screen w-full items-center justify-center px-12 text-white">
       <div className="flex w-full flex-col items-center justify-center text-center">
         <AnimatedElement>
           <h2 className="mb-3 font-carrig text-xl">DATE & TIME</h2>

--- a/src/components/event-description/event-description.tsx
+++ b/src/components/event-description/event-description.tsx
@@ -6,7 +6,7 @@ import SyailendraLogo3 from "/public/assets/images/syailendra-logo3.svg";
 
 const EventDescription = () => {
   return (
-    <div className="relative mt-35 flex min-h-[843px] flex-col items-center justify-center">
+    <div className="relative flex min-h-screen flex-col items-center justify-center">
       <div className="mx-14 flex min-h-[843px] flex-col items-center justify-center text-center font-avenir text-sm text-white">
         <AnimatedElement needScroll={false}>
           <div className="flex flex-col items-center justify-center">


### PR DESCRIPTION
This pull request primarily focuses on adjusting layout and styling across multiple components to improve responsiveness and alignment. The changes include updates to positioning, height properties, and spacing for better visual consistency.

### Layout and Position Adjustments:

* [`src/app/main/page.tsx`](diffhunk://#diff-e6951db9231d18be8aeaccf97978b4206f55adb1c5078714a9d51a45d35234d2L28-R28): Updated the positioning of various elements, including `top` and `left` values for ornaments and background dots, to improve alignment and spacing. For example, the `WaveLine2` ornament's `top` value was changed from `1050px` to `1700px`. [[1]](diffhunk://#diff-e6951db9231d18be8aeaccf97978b4206f55adb1c5078714a9d51a45d35234d2L28-R28) [[2]](diffhunk://#diff-e6951db9231d18be8aeaccf97978b4206f55adb1c5078714a9d51a45d35234d2L40-R60)

### Height and Responsiveness Updates:

* [`src/components/attendance/attendance.tsx`](diffhunk://#diff-2581850eda966fb1ff729862e0e6dfdbd1026f70d84a39515d5606545793e7bfL9-R9): Replaced `min-h-[842px]` with `min-h-screen` to ensure full-screen height responsiveness for the `Attendance` component.
* [`src/components/date-time/date-time.tsx`](diffhunk://#diff-3bc8564a23be23faf23921e0b664a7dd56ddd7d45f234865972c17fabe4e5749L8-R8): Updated `min-h-[844px]` to `min-h-screen` for better responsiveness in the `DateTime` component.
* [`src/components/event-description/event-description.tsx`](diffhunk://#diff-cbf889a5e31d6a0b2c153e86b593d3c5891760e3f3d8bbebb429ae7e20d5814dL9-R9): Changed `min-h-[843px]` to `min-h-screen` for the `EventDescription` component to improve layout consistency across different screen sizes.